### PR TITLE
Second round of query fixes

### DIFF
--- a/examples/spec/integration/query_workflow_spec.rb
+++ b/examples/spec/integration/query_workflow_spec.rb
@@ -22,7 +22,7 @@ describe QueryWorkflow, :integration do
 
     # Query with unregistered handler
     expect { Temporal.query_workflow(described_class, 'unknown_query', workflow_id, run_id) }
-      .to raise_error(Temporal::QueryFailedFailure, 'Workflow did not register a handler for unknown_query')
+      .to raise_error(Temporal::QueryFailed, 'Workflow did not register a handler for unknown_query')
 
     Temporal.signal_workflow(described_class, 'make_progress', workflow_id, run_id)
 
@@ -45,10 +45,10 @@ describe QueryWorkflow, :integration do
       .to eq 2
 
     expect { Temporal.query_workflow(described_class, 'unknown_query', workflow_id, run_id) }
-      .to raise_error(Temporal::QueryFailedFailure, 'Workflow did not register a handler for unknown_query')
+      .to raise_error(Temporal::QueryFailed, 'Workflow did not register a handler for unknown_query')
 
     # Now that the workflow is completed, test a query with a reject condition satisfied
     expect { Temporal.query_workflow(described_class, 'state', workflow_id, run_id, query_reject_condition: :not_open) }
-      .to raise_error(Temporal::QueryFailedFailure, 'Query rejected: status WORKFLOW_EXECUTION_STATUS_COMPLETED')
+      .to raise_error(Temporal::QueryFailed, 'Query rejected: status WORKFLOW_EXECUTION_STATUS_COMPLETED')
   end
 end

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -499,14 +499,14 @@ module Temporal
         begin
           response = client.query_workflow(request)
         rescue ::GRPC::InvalidArgument => e
-          raise Temporal::QueryFailedFailure, e.details
+          raise Temporal::QueryFailed, e.details
         end
 
         if response.query_rejected
           rejection_status = response.query_rejected.status || 'not specified by server'
-          raise Temporal::QueryFailedFailure, "Query rejected: status #{rejection_status}"
+          raise Temporal::QueryFailed, "Query rejected: status #{rejection_status}"
         elsif !response.query_result
-          raise Temporal::QueryFailedFailure, 'Invalid response from server'
+          raise Temporal::QueryFailed, 'Invalid response from server'
         else
           from_query_payloads(response.query_result)
         end

--- a/lib/temporal/errors.rb
+++ b/lib/temporal/errors.rb
@@ -67,7 +67,7 @@ module Temporal
   class FeatureVersionNotSupportedFailure < ApiError; end
   class NamespaceAlreadyExistsFailure < ApiError; end
   class CancellationAlreadyRequestedFailure < ApiError; end
-  class QueryFailedFailure < ApiError; end
+  class QueryFailed < ApiError; end
   class UnexpectedResponse < ApiError; end
 
 end

--- a/lib/temporal/workflow/context.rb
+++ b/lib/temporal/workflow/context.rb
@@ -16,12 +16,12 @@ require 'temporal/workflow/state_manager'
 module Temporal
   class Workflow
     class Context
-      attr_reader :metadata, :config, :query_handlers
+      attr_reader :metadata, :config
 
-      def initialize(state_manager, dispatcher, workflow_class, metadata, config)
+      def initialize(state_manager, dispatcher, workflow_class, metadata, config, query_registry)
         @state_manager = state_manager
         @dispatcher = dispatcher
-        @query_handlers = {}
+        @query_registry = query_registry
         @workflow_class = workflow_class
         @metadata = metadata
         @completed = false
@@ -300,7 +300,7 @@ module Temporal
       end
 
       def on_query(query, &block)
-        query_handlers[query] = block
+        query_registry.register(query, &block)
       end
 
       def cancel_activity(activity_id)
@@ -387,7 +387,7 @@ module Temporal
 
       private
 
-      attr_reader :state_manager, :dispatcher, :workflow_class
+      attr_reader :state_manager, :dispatcher, :workflow_class, :query_registry
 
       def completed!
         @completed = true

--- a/lib/temporal/workflow/query_registry.rb
+++ b/lib/temporal/workflow/query_registry.rb
@@ -1,0 +1,33 @@
+require 'temporal/errors'
+
+module Temporal
+  class Workflow
+    class QueryRegistry
+      def initialize
+        @handlers = {}
+      end
+
+      def register(type, &handler)
+        if handlers.key?(type)
+          warn "[NOTICE] Overwriting a query handler for #{type}"
+        end
+
+        handlers[type] = handler
+      end
+
+      def handle(type, args = nil)
+        handler = handlers[type]
+
+        unless handler
+          raise Temporal::QueryFailedFailure, "Workflow did not register a handler for #{type}"
+        end
+
+        handler.call(*args)
+      end
+
+      private
+
+      attr_reader :handlers
+    end
+  end
+end

--- a/lib/temporal/workflow/query_registry.rb
+++ b/lib/temporal/workflow/query_registry.rb
@@ -19,7 +19,7 @@ module Temporal
         handler = handlers[type]
 
         unless handler
-          raise Temporal::QueryFailedFailure, "Workflow did not register a handler for #{type}"
+          raise Temporal::QueryFailed, "Workflow did not register a handler for #{type}"
         end
 
         handler.call(*args)

--- a/rbi/temporal-ruby.rbi
+++ b/rbi/temporal-ruby.rbi
@@ -39,5 +39,5 @@ module Temporal
   class FeatureVersionNotSupportedFailure; end
   class NamespaceAlreadyExistsFailure; end
   class CancellationAlreadyRequestedFailure; end
-  class QueryFailedFailure; end
+  class QueryFailed; end
 end

--- a/spec/unit/lib/temporal/workflow/context_spec.rb
+++ b/spec/unit/lib/temporal/workflow/context_spec.rb
@@ -7,10 +7,18 @@ class MyTestWorkflow < Temporal::Workflow; end
 describe Temporal::Workflow::Context do
   let(:state_manager) { instance_double('Temporal::Workflow::StateManager') }
   let(:dispatcher) { instance_double('Temporal::Workflow::Dispatcher') }
+  let(:query_registry) { instance_double('Temporal::Workflow::QueryRegistry') }
   let(:metadata) { instance_double('Temporal::Metadata::Workflow') }
-  let(:workflow_context) {
-    Temporal::Workflow::Context.new(state_manager, dispatcher, MyTestWorkflow, metadata, Temporal.configuration)
-  }
+  let(:workflow_context) do
+    Temporal::Workflow::Context.new(
+      state_manager,
+      dispatcher,
+      MyTestWorkflow,
+      metadata,
+      Temporal.configuration,
+      query_registry
+    )
+  end
 
   describe '#upsert_search_attributes' do
     it 'does not accept nil' do

--- a/spec/unit/lib/temporal/workflow/context_spec.rb
+++ b/spec/unit/lib/temporal/workflow/context_spec.rb
@@ -20,6 +20,20 @@ describe Temporal::Workflow::Context do
     )
   end
 
+  describe '#on_query' do
+    let(:handler) { Proc.new {} }
+
+    before { allow(query_registry).to receive(:register) }
+
+    it 'registers a query with the query registry' do
+      workflow_context.on_query('test-query', &handler)
+
+      expect(query_registry).to have_received(:register).with('test-query') do |&block|
+        expect(block).to eq(handler)
+      end
+    end
+  end
+
   describe '#upsert_search_attributes' do
     it 'does not accept nil' do
       expect do

--- a/spec/unit/lib/temporal/workflow/executor_spec.rb
+++ b/spec/unit/lib/temporal/workflow/executor_spec.rb
@@ -2,6 +2,7 @@ require 'temporal/workflow/executor'
 require 'temporal/workflow/history'
 require 'temporal/workflow'
 require 'temporal/workflow/task_processor'
+require 'temporal/workflow/query_registry'
 
 describe Temporal::Workflow::Executor do
   subject { described_class.new(workflow, history, workflow_metadata, config) }
@@ -81,7 +82,7 @@ describe Temporal::Workflow::Executor do
   end
 
   describe '#process_queries' do
-    let(:context) { subject.send(:context) }
+    let(:query_registry) { Temporal::Workflow::QueryRegistry.new }
     let(:query_1_result) { 42 }
     let(:query_2_error) { StandardError.new('Test query failure') }
     let(:queries) do
@@ -93,9 +94,9 @@ describe Temporal::Workflow::Executor do
     end
 
     before do
-      subject.run
-      context.on_query('success') { query_1_result }
-      context.on_query('failure') { raise query_2_error }
+      allow(Temporal::Workflow::QueryRegistry).to receive(:new).and_return(query_registry)
+      query_registry.register('success') { query_1_result }
+      query_registry.register('failure') { raise query_2_error }
     end
 
     it 'returns query results' do

--- a/spec/unit/lib/temporal/workflow/executor_spec.rb
+++ b/spec/unit/lib/temporal/workflow/executor_spec.rb
@@ -108,7 +108,7 @@ describe Temporal::Workflow::Executor do
       expect(results['2']).to be_a(Temporal::Workflow::QueryResult::Failure)
       expect(results['2'].error).to eq(query_2_error)
       expect(results['3']).to be_a(Temporal::Workflow::QueryResult::Failure)
-      expect(results['3'].error).to be_a(Temporal::QueryFailedFailure)
+      expect(results['3'].error).to be_a(Temporal::QueryFailed)
       expect(results['3'].error.message).to eq('Workflow did not register a handler for unknown')
     end
   end

--- a/spec/unit/lib/temporal/workflow/query_registry_spec.rb
+++ b/spec/unit/lib/temporal/workflow/query_registry_spec.rb
@@ -60,7 +60,7 @@ describe Temporal::Workflow::QueryRegistry do
       it 'raises' do
         expect do
           subject.handle('test-query')
-        end.to raise_error(Temporal::QueryFailedFailure, 'Workflow did not register a handler for test-query')
+        end.to raise_error(Temporal::QueryFailed, 'Workflow did not register a handler for test-query')
       end
     end
   end

--- a/spec/unit/lib/temporal/workflow/query_registry_spec.rb
+++ b/spec/unit/lib/temporal/workflow/query_registry_spec.rb
@@ -1,0 +1,67 @@
+require 'temporal/workflow/query_registry'
+
+describe Temporal::Workflow::QueryRegistry do
+  subject { described_class.new }
+
+  describe '#register' do
+    let(:handler) { Proc.new {} }
+
+    it 'registers a query handler' do
+      subject.register('test-query', &handler)
+
+      expect(subject.send(:handlers)['test-query']).to eq(handler)
+    end
+
+    context 'when query handler is already registered' do
+      let(:handler_2) { Proc.new {} }
+
+      before { subject.register('test-query', &handler) }
+
+      it 'warns' do
+        allow(subject).to receive(:warn)
+
+        subject.register('test-query', &handler_2)
+
+        expect(subject)
+          .to have_received(:warn)
+          .with('[NOTICE] Overwriting a query handler for test-query')
+      end
+
+      it 're-registers a query handler' do
+        subject.register('test-query', &handler_2)
+
+        expect(subject.send(:handlers)['test-query']).to eq(handler_2)
+      end
+    end
+  end
+
+  describe '#handle' do
+    context 'when a query handler has been registered' do
+      let(:handler) { Proc.new { 42 } }
+
+      before { subject.register('test-query', &handler) }
+
+      it 'runs the handler and returns the result' do
+        expect(subject.handle('test-query')).to eq(42)
+      end
+    end
+
+    context 'when a query handler has been registered with args' do
+      let(:handler) { Proc.new { |arg_1, arg_2| arg_1 + arg_2 } }
+
+      before { subject.register('test-query', &handler) }
+
+      it 'runs the handler and returns the result' do
+        expect(subject.handle('test-query', [3, 5])).to eq(8)
+      end
+    end
+
+    context 'when a query handler has not been registered' do
+      it 'raises' do
+        expect do
+          subject.handle('test-query')
+        end.to raise_error(Temporal::QueryFailedFailure, 'Workflow did not register a handler for test-query')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This one focuses on moving query handler registration into a `QueryRegistry` class to avoid the nasty `@context` fix on the `Executor`. Tests are added for all the missing bits