### PR TITLE
[wip] Add reproduction case for workflows not completing from signal

### DIFF
--- a/examples/spec/integration/repro_workflow_spec.rb
+++ b/examples/spec/integration/repro_workflow_spec.rb
@@ -6,7 +6,8 @@ describe ReproWorkflow do
     workflow_id = SecureRandom.uuid
     run_id = Temporal.start_workflow(
       ReproWorkflow,
-      options: { workflow_id: workflow_id }
+      # I'm having issues with the latest docker-compose not being able to terminate workflows easily
+      options: { workflow_id: workflow_id, timeouts: { run: 60 } }
     )
 
     Temporal.signal_workflow(ReproWorkflow, 'finish', workflow_id, run_id)

--- a/lib/temporal/client.rb
+++ b/lib/temporal/client.rb
@@ -246,6 +246,9 @@ module Temporal
       end
       history = Workflow::History.new(history_response.history.events)
       closed_event = history.events.first
+
+      puts("!!! history: (#{history_response})")
+
       case closed_event.type
       when 'WORKFLOW_EXECUTION_COMPLETED'
         payloads = closed_event.attributes.result

--- a/lib/temporal/workflow/dispatcher.rb
+++ b/lib/temporal/workflow/dispatcher.rb
@@ -75,6 +75,18 @@ module Temporal
           .select { |_, event_struct| match?(event_struct, event_name) }
           .sort
           .map { |_, event_struct| event_struct }
+
+        # RUNS ALL THE HANDLERS AT THE END LIKE BEFORE
+        #handlers[target]
+        #  .select { |_, event_struct| match?(event_struct, event_name) }
+        #  .sort
+        #  .map { |_, event_struct| event_struct }
+        #  .concat(
+        #    handlers[TARGET_WILDCARD]
+        #    .select { |_, event_struct| match?(event_struct, event_name) }
+        #    .sort
+        #    .map { |_, event_struct| event_struct }
+        #  )
       end
 
       def match?(event_struct, event_name)


### PR DESCRIPTION
@dwillett I've added extra logging to your repro. The output can be seen at https://gist.github.com/jeffschoner/a4be45f7f74f76480f13cd4624d60b2e

This is consistent with what I had sketched out over Slack, where the condition is evaluated before the timer callback runs. These are sequenced in this way because the `wait_until` happens before the timer is started (which only happens once the signal comes in which is after the workflow is started).

### A few observations/notes:

The signal is sent so quickly after the workflow is started that it gets handled in the first workflow task. This simplifies what I mentioned in a Slack (2 workflow tasks instead of 3), but does not affect the behavior.

In the outputs, the handle registered for * * is for the `wait_until`. These are vaguely identified because they're not associated with a specific event. They run every time something in the workflow changes after they're registered (hence, the `*` for wildcard).

The two replays help a bit to show why dispatches need to be called in a deterministic way upon replay. The second workflow task begins exactly as the first ran. If this didn't runthis way, there's potential for non-determinism because there are little blocks of workflow code running between many of the log lines. A different order could mean the workflow exiting at a different point in execution (missing the start of a timer or activity), or not running an activity or timer in a callback
83), this sort of workflow would be broken.

When I restore the behavior of calling the wildcard handlers (aka the handlers for `wait_until`) after all the other handlers, your test does pass. I'm still working on a getting a repro for the bug I was seeing before that caused me to make https://github.com/coinbase/temporal-ruby/pull/183. Unfortunately, the workflow where we saw this before is complex and uses a bunch of internal code, so it can't be surfaced publicly very easily.